### PR TITLE
Wrap carousel script in DOMContentLoaded event

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,189 +102,191 @@
 
   <!-- ===== Carousel + Lightbox Script (single unified script) ===== -->
   <script>
-  (function () {
-    const slideImgs = Array.from({ length: 8 }, (_, i) => `./${i + 1}.jpg`);
-    const track = document.querySelector('[data-carousel-track]');
-    slideImgs.forEach((src, i) => {
-      const li = document.createElement('li');
-      li.className = 'slide';
-      const img = document.createElement('img');
-      img.src = src;
-      img.alt = `Project slide ${i + 1}`;
-      li.appendChild(img);
-      track.appendChild(li);
-    });
-
-    /** UTIL **/
-    function el(tag, attrs = {}, html = "") {
-      const n = document.createElement(tag);
-      Object.entries(attrs).forEach(([k, v]) => {
-        if (k === "class") n.className = v;
-        else if (k.startsWith("on") && typeof v === "function") n.addEventListener(k.slice(2), v);
-        else n.setAttribute(k, v);
+  document.addEventListener('DOMContentLoaded', () => {
+    (function () {
+      const slideImgs = Array.from({ length: 8 }, (_, i) => `./${i + 1}.jpg`);
+      const track = document.querySelector('[data-carousel-track]');
+      slideImgs.forEach((src, i) => {
+        const li = document.createElement('li');
+        li.className = 'slide';
+        const img = document.createElement('img');
+        img.src = src;
+        img.alt = `Project slide ${i + 1}`;
+        li.appendChild(img);
+        track.appendChild(li);
       });
-      if (html) n.innerHTML = html;
-      return n;
-    }
-
-    /** LIGHTBOX (single instance) **/
-    const lightbox = el("div", { id: "lightbox", hidden: "" });
-    lightbox.innerHTML = `
-      <div class="lb-overlay" data-lb-close></div>
-      <figure class="lb-content" role="dialog" aria-modal="true" aria-label="Slide">
-        <button class="lb-close" aria-label="Close" data-lb-close>&times;</button>
-        <button class="lb-nav lb-prev" aria-label="Previous" data-lb-prev>&larr;</button>
-        <img class="lb-img" src="" alt="Expanded slide">
-        <button class="lb-nav lb-next" aria-label="Next" data-lb-next>&rarr;</button>
-        <figcaption class="lb-cap"><span data-lb-count>1/1</span></figcaption>
-      </figure>`;
-    document.body.appendChild(lightbox);
-
-    const lbImg   = lightbox.querySelector(".lb-img");
-    const lbCount = lightbox.querySelector("[data-lb-count]");
-    const lbPrev  = lightbox.querySelector("[data-lb-prev]");
-    const lbNext  = lightbox.querySelector("[data-lb-next]");
-    const lbCloseBtns = lightbox.querySelectorAll("[data-lb-close]");
-
-    let lbList = []; // list of images for the current carousel
-    let lbIndex = 0;
-
-    function lbRender() {
-      if (!lbList.length) return;
-      lbImg.src = lbList[lbIndex].src;
-      lbImg.alt = lbList[lbIndex].alt || "Expanded slide";
-      lbCount.textContent = (lbIndex + 1) + "/" + lbList.length;
-    }
-    function lbOpen(images, startIndex) {
-      lbList = images;
-      lbIndex = Math.max(0, Math.min(startIndex, lbList.length - 1));
-      lightbox.removeAttribute("hidden");
-      lightbox.setAttribute("aria-hidden", "false");
-      lbRender();
-    }
-    function lbClose() {
-      lightbox.setAttribute("aria-hidden", "true");
-      lightbox.setAttribute("hidden", "");
-    }
-    function lbPrevFn(){ lbIndex = (lbIndex - 1 + lbList.length) % lbList.length; lbRender(); }
-    function lbNextFn(){ lbIndex = (lbIndex + 1) % lbList.length; lbRender(); }
-
-    lbPrev.addEventListener("click", lbPrevFn);
-    lbNext.addEventListener("click", lbNextFn);
-    lbCloseBtns.forEach(b => b.addEventListener("click", lbClose));
-    lightbox.addEventListener("click", (e) => {
-      if (e.target.matches(".lb-overlay,[data-lb-close]")) lbClose();
-    });
-    window.addEventListener("keydown", (e) => {
-      if (lightbox.hasAttribute("hidden")) return;
-      if (e.key === "Escape") lbClose();
-      if (e.key === "ArrowLeft") lbPrevFn();
-      if (e.key === "ArrowRight") lbNextFn();
-    });
-
-    /** CAROUSEL **/
-    document.querySelectorAll("[data-carousel]").forEach((root) => {
-      const track    = root.querySelector("[data-carousel-track]");
-      const viewport = root.querySelector("[data-carousel-viewport]") || root.querySelector(".viewport");
-      const prevBtn  = root.querySelector("[data-carousel-prev]");
-      const nextBtn  = root.querySelector("[data-carousel-next]");
-      const dotsWrap = root.querySelector("[data-carousel-dots]");
-
-      const slides = Array.from(track.querySelectorAll(".slide"));
-      const imgs   = slides.map(s => s.querySelector("img"));
-
-      // Add eye icon overlay button to each slide
-      slides.forEach((slide, i) => {
-        const eyeBtn = el(
-          "button",
-          { class: "expand", "aria-label": "Expand slide " + (i + 1), "data-expand": String(i) },
-          // Inline SVG ensures perfect centering/availability (no external icon font needed)
-          `<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false" style="display:block">
-             <path fill="currentColor" d="M12 5c-7 0-11 7-11 7s4 7 11 7 11-7 11-7-4-7-11-7zm0 12a5 5 0 110-10 5 5 0 010 10zm0-2.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z"/>
-           </svg>`
-        );
-        eyeBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          lbOpen(imgs, i);
+  
+      /** UTIL **/
+      function el(tag, attrs = {}, html = "") {
+        const n = document.createElement(tag);
+        Object.entries(attrs).forEach(([k, v]) => {
+          if (k === "class") n.className = v;
+          else if (k.startsWith("on") && typeof v === "function") n.addEventListener(k.slice(2), v);
+          else n.setAttribute(k, v);
         });
-        slide.appendChild(eyeBtn);
-
-        // Clicking the image also opens lightbox
-        imgs[i].addEventListener("click", () => lbOpen(imgs, i));
-        // Performance attrs
-        imgs[i].setAttribute("loading", "lazy");
-        imgs[i].setAttribute("decoding", "async");
-        imgs[i].setAttribute("fetchpriority", "low");
+        if (html) n.innerHTML = html;
+        return n;
+      }
+  
+      /** LIGHTBOX (single instance) **/
+      const lightbox = el("div", { id: "lightbox", hidden: "" });
+      lightbox.innerHTML = `
+        <div class="lb-overlay" data-lb-close></div>
+        <figure class="lb-content" role="dialog" aria-modal="true" aria-label="Slide">
+          <button class="lb-close" aria-label="Close" data-lb-close>&times;</button>
+          <button class="lb-nav lb-prev" aria-label="Previous" data-lb-prev>&larr;</button>
+          <img class="lb-img" src="" alt="Expanded slide">
+          <button class="lb-nav lb-next" aria-label="Next" data-lb-next>&rarr;</button>
+          <figcaption class="lb-cap"><span data-lb-count>1/1</span></figcaption>
+        </figure>`;
+      document.body.appendChild(lightbox);
+  
+      const lbImg   = lightbox.querySelector(".lb-img");
+      const lbCount = lightbox.querySelector("[data-lb-count]");
+      const lbPrev  = lightbox.querySelector("[data-lb-prev]");
+      const lbNext  = lightbox.querySelector("[data-lb-next]");
+      const lbCloseBtns = lightbox.querySelectorAll("[data-lb-close]");
+  
+      let lbList = []; // list of images for the current carousel
+      let lbIndex = 0;
+  
+      function lbRender() {
+        if (!lbList.length) return;
+        lbImg.src = lbList[lbIndex].src;
+        lbImg.alt = lbList[lbIndex].alt || "Expanded slide";
+        lbCount.textContent = (lbIndex + 1) + "/" + lbList.length;
+      }
+      function lbOpen(images, startIndex) {
+        lbList = images;
+        lbIndex = Math.max(0, Math.min(startIndex, lbList.length - 1));
+        lightbox.removeAttribute("hidden");
+        lightbox.setAttribute("aria-hidden", "false");
+        lbRender();
+      }
+      function lbClose() {
+        lightbox.setAttribute("aria-hidden", "true");
+        lightbox.setAttribute("hidden", "");
+      }
+      function lbPrevFn(){ lbIndex = (lbIndex - 1 + lbList.length) % lbList.length; lbRender(); }
+      function lbNextFn(){ lbIndex = (lbIndex + 1) % lbList.length; lbRender(); }
+  
+      lbPrev.addEventListener("click", lbPrevFn);
+      lbNext.addEventListener("click", lbNextFn);
+      lbCloseBtns.forEach(b => b.addEventListener("click", lbClose));
+      lightbox.addEventListener("click", (e) => {
+        if (e.target.matches(".lb-overlay,[data-lb-close]")) lbClose();
       });
-
-      // Dots
-      let dots = [];
-      if (dotsWrap) {
-        slides.forEach((_, i) => {
-          const b = el("button", { type: "button", role: "tab", "aria-label": "Go to slide " + (i + 1) });
-          if (i === 0) b.setAttribute("aria-selected", "true");
-          b.addEventListener("click", () => goTo(i));
-          dotsWrap.appendChild(b);
+      window.addEventListener("keydown", (e) => {
+        if (lightbox.hasAttribute("hidden")) return;
+        if (e.key === "Escape") lbClose();
+        if (e.key === "ArrowLeft") lbPrevFn();
+        if (e.key === "ArrowRight") lbNextFn();
+      });
+  
+      /** CAROUSEL **/
+      document.querySelectorAll("[data-carousel]").forEach((root) => {
+        const track    = root.querySelector("[data-carousel-track]");
+        const viewport = root.querySelector("[data-carousel-viewport]") || root.querySelector(".viewport");
+        const prevBtn  = root.querySelector("[data-carousel-prev]");
+        const nextBtn  = root.querySelector("[data-carousel-next]");
+        const dotsWrap = root.querySelector("[data-carousel-dots]");
+  
+        const slides = Array.from(track.querySelectorAll(".slide"));
+        const imgs   = slides.map(s => s.querySelector("img"));
+  
+        // Add eye icon overlay button to each slide
+        slides.forEach((slide, i) => {
+          const eyeBtn = el(
+            "button",
+            { class: "expand", "aria-label": "Expand slide " + (i + 1), "data-expand": String(i) },
+            // Inline SVG ensures perfect centering/availability (no external icon font needed)
+            `<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false" style="display:block">
+               <path fill="currentColor" d="M12 5c-7 0-11 7-11 7s4 7 11 7 11-7 11-7-4-7-11-7zm0 12a5 5 0 110-10 5 5 0 010 10zm0-2.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z"/>
+             </svg>`
+          );
+          eyeBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            lbOpen(imgs, i);
+          });
+          slide.appendChild(eyeBtn);
+  
+          // Clicking the image also opens lightbox
+          imgs[i].addEventListener("click", () => lbOpen(imgs, i));
+          // Performance attrs
+          imgs[i].setAttribute("loading", "lazy");
+          imgs[i].setAttribute("decoding", "async");
+          imgs[i].setAttribute("fetchpriority", "low");
         });
-        dots = Array.from(dotsWrap.children);
-      }
-
-      // State
-      let index = 0;
-      function update() {
-        const offset = -index * viewport.clientWidth;
-        track.style.transform = `translateX(${offset}px)`;
-        dots.forEach((d, i) => d.setAttribute("aria-selected", i === index ? "true" : "false"));
-      }
-      function goTo(i) { index = Math.max(0, Math.min(i, slides.length - 1)); update(); }
-      function next()  { goTo(index + 1); }
-      function prev()  { goTo(index - 1); }
-
-      // Buttons/keys
-      nextBtn.addEventListener("click", next);
-      prevBtn.addEventListener("click", prev);
-      root.addEventListener("keydown", (e) => {
-        if (e.key === "ArrowRight") { e.preventDefault(); next(); }
-        if (e.key === "ArrowLeft")  { e.preventDefault(); prev(); }
+  
+        // Dots
+        let dots = [];
+        if (dotsWrap) {
+          slides.forEach((_, i) => {
+            const b = el("button", { type: "button", role: "tab", "aria-label": "Go to slide " + (i + 1) });
+            if (i === 0) b.setAttribute("aria-selected", "true");
+            b.addEventListener("click", () => goTo(i));
+            dotsWrap.appendChild(b);
+          });
+          dots = Array.from(dotsWrap.children);
+        }
+  
+        // State
+        let index = 0;
+        function update() {
+          const offset = -index * viewport.clientWidth;
+          track.style.transform = `translateX(${offset}px)`;
+          dots.forEach((d, i) => d.setAttribute("aria-selected", i === index ? "true" : "false"));
+        }
+        function goTo(i) { index = Math.max(0, Math.min(i, slides.length - 1)); update(); }
+        function next()  { goTo(index + 1); }
+        function prev()  { goTo(index - 1); }
+  
+        // Buttons/keys
+        nextBtn.addEventListener("click", next);
+        prevBtn.addEventListener("click", prev);
+        root.addEventListener("keydown", (e) => {
+          if (e.key === "ArrowRight") { e.preventDefault(); next(); }
+          if (e.key === "ArrowLeft")  { e.preventDefault(); prev(); }
+        });
+  
+        // Drag / swipe
+        let isDown = false, startX = 0, curX = 0, startOffset = 0;
+        const threshold = () => viewport.clientWidth * 0.18;
+  
+        viewport.addEventListener("pointerdown", (e) => {
+          isDown = true;
+          startX = curX = e.clientX;
+          startOffset = -index * viewport.clientWidth;
+          track.style.transition = "none";
+          viewport.setPointerCapture(e.pointerId);
+        });
+        viewport.addEventListener("pointermove", (e) => {
+          if (!isDown) return;
+          curX = e.clientX;
+          const dx = curX - startX;
+          track.style.transform = `translateX(${startOffset + dx}px)`;
+        });
+        function endPointer(e) {
+          if (!isDown) return;
+          isDown = false;
+          track.style.transition = "";
+          const dx = curX - startX;
+          if (dx < -threshold()) next();
+          else if (dx > threshold()) prev();
+          else update();
+          viewport.releasePointerCapture?.(e.pointerId);
+        }
+        viewport.addEventListener("pointerup", endPointer);
+        viewport.addEventListener("pointercancel", endPointer);
+        viewport.addEventListener("pointerleave", endPointer);
+  
+        window.addEventListener("resize", update);
+  
+        // Init
+        update();
       });
-
-      // Drag / swipe
-      let isDown = false, startX = 0, curX = 0, startOffset = 0;
-      const threshold = () => viewport.clientWidth * 0.18;
-
-      viewport.addEventListener("pointerdown", (e) => {
-        isDown = true;
-        startX = curX = e.clientX;
-        startOffset = -index * viewport.clientWidth;
-        track.style.transition = "none";
-        viewport.setPointerCapture(e.pointerId);
-      });
-      viewport.addEventListener("pointermove", (e) => {
-        if (!isDown) return;
-        curX = e.clientX;
-        const dx = curX - startX;
-        track.style.transform = `translateX(${startOffset + dx}px)`;
-      });
-      function endPointer(e) {
-        if (!isDown) return;
-        isDown = false;
-        track.style.transition = "";
-        const dx = curX - startX;
-        if (dx < -threshold()) next();
-        else if (dx > threshold()) prev();
-        else update();
-        viewport.releasePointerCapture?.(e.pointerId);
-      }
-      viewport.addEventListener("pointerup", endPointer);
-      viewport.addEventListener("pointercancel", endPointer);
-      viewport.addEventListener("pointerleave", endPointer);
-
-      window.addEventListener("resize", update);
-
-      // Init
-      update();
-    });
-  })();
+    })();
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure inline carousel/lightbox script executes only after HTML parsing by wrapping its IIFE in a DOMContentLoaded listener.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaae1c58ec8327b362d54c02e49859